### PR TITLE
Recursive media type using identifier example

### DIFF
--- a/types/design/recursive.go
+++ b/types/design/recursive.go
@@ -69,3 +69,13 @@ var HashHashPrismMedia = MediaType("vnd.goadesign.examples.hashhashprism", func(
 		Attribute("hash_hash")
 	})
 })
+
+var RecursivePrismMedia = MediaType("vnd.goadesign.examples.recursiveprism", func() {
+	Description("RecursivePrismMedia is a media type that contains children of the same type")
+	Attributes(func() {
+		Attribute("children", CollectionOf("vnd.goadesign.examples.recursiveprism"), "Children")
+	})
+	View("default", func() {
+		Attribute("children")
+	})
+})


### PR DESCRIPTION
Added example showcasing a recursive media type using the media type identifier
