### PR TITLE
http.Client is now initialized in client by passing nil

### DIFF
--- a/gopherjs/public/main.go
+++ b/gopherjs/public/main.go
@@ -125,8 +125,7 @@ func onLoad() {
 }
 
 func main() {
-	hc := &http.Client{}
-	c = client.New(hc)
+	c = client.New(nil)
 	c.Host = "127.0.0.1:8080"
 	ctx = context.Background()
 	doc = js.Global.Get("document")


### PR DESCRIPTION
Resolves:
```
public/main.go:129:17: cannot use hc (variable of type *net/http.Client) as github.com/goadesign/goa/client.Doer value in argument to client.New: wrong type for method Do
generate.go:5: running "gopherjs": exit status 1
```
(http.Client is now initialized in [client.go](https://github.com/goadesign/goa/blob/master/client/client.go) by passing nil to [client.New](https://github.com/goadesign/goa/blob/master/client/client.go#L41-L46))