### PR TITLE
fix: Remove references to cloning weather sample with gonew

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,7 @@ $ cd basic
 ```
 
 A [fully instrumented example](https://github.com/goadesign/clue/tree/main/example/weather) of a
-system consisting of multiple Goa microservices is included in the [Clue](https://github.com/goadesign/clue) repo.
-
-To get started with the Goa Clue example, you can use the gonew command to clone it into your own repository:
-
-```shell
-$ gonew github.com/goadesign/clue/example/weather github.com/<your_repo>/weather
-$ cd weather
-```
-Please follow the README in the Clue repository for more details on running and testing the Goa Clue example.
+system consisting of multiple Goa microservices is included in the [Clue](https://github.com/goadesign/clue) repo. Please follow the README in the Clue repository for more details on running and testing the Goa Clue example.
 
 As you study each example consider contributing back by providing better or more complete docs,
 adding clarifying comments to code or fixing any error you may run across!


### PR DESCRIPTION
issue:https://github.com/goadesign/examples/issues/131

I apologize for the oversight in the previous PR https://github.com/goadesign/examples/pull/130/commits/d9ffbdce733e62214d9a59b30f284f5b29747b99. It turns out that the weather example from the clue repository cannot be cloned using the gonew command. The reason is that the weather example consists of multiple services and is not structured as a single module. Since gonew is designed to clone a single module as a template, it cannot target the weather example. 